### PR TITLE
Make default login for use during development

### DIFF
--- a/src/Model/FrontEndAPI/FrontEndMainMenu.cs
+++ b/src/Model/FrontEndAPI/FrontEndMainMenu.cs
@@ -1,11 +1,31 @@
 namespace FrontEndAPI;
-using Survey;
 
-    public static class FrontEndMainMenu {
-        public static bool ValidateSuperUser(string username, string password) {
-            return false;
-        }
-        public static IGetSurvey? GetSurvey(int surveyId) {
-            return null;
-        }
+public static class FrontEndMainMenu
+{
+    private const string DeveloperUserName = "10xdeveloper";
+    private const string DeveloperPassword = "ornot";
+    private const int DeveloperPin = 123456;
+
+    public static bool ValidateSuperUser(string username, string password) {
+        return username == DeveloperUserName && password == DeveloperPassword;
     }
+    public static IGetSurvey? GetSurvey(int surveyId)
+    {
+        return surveyId == DeveloperPin
+            ? new MockSurvey()
+            : null;
+    }
+
+    private class MockSurvey : IGetSurvey
+    {
+        public Question.IGetQuestion GetNextQuestion {get;}
+
+        public Question.IGetQuestion GetQuestionA {get;}
+
+        public Question.IGetQuestion GetQuestionB {get;}
+
+        public Answer.IGetAnswer GetAnswer {get;}
+
+        public Question.IGetQuestion GetPreviousQuestion {get;}
+    }
+}


### PR DESCRIPTION
This PR does two things to `FrontEndMainMenu`:
1. Make indentation to follow standard elsewhere
2. Adds a temporary developer login so we can actually use the API in the front end