### PR TITLE
Changes GetPicture to string

### DIFF
--- a/src/Model/Question/IGetQuestion.cs
+++ b/src/Model/Question/IGetQuestion.cs
@@ -2,10 +2,11 @@ namespace Question;
 
 using System.Drawing;
 
-public interface IGetQuestion {
-int GetId {get;}
-QuestionType GetType {get;}
-string GetCaption {get;}
-Image GetPicture {get;}
-string GetText {get;}
+public interface IGetQuestion
+{
+    int GetId { get; }
+    QuestionType GetType { get; }
+    string GetCaption { get; }
+    string GetPicture { get; }
+    string GetText { get; }
 }


### PR DESCRIPTION
Vi har brug for billedet som en specifik type i FrontEnd, så det giver nok bedre mening at holde det som en string i backend og bare gemme hele pathen til når vi skal vise den.