### PR TITLE
Add functionality to check whether current index is first or last in survey

### DIFF
--- a/src/Model/Survey/IReadOnlySurvey.cs
+++ b/src/Model/Survey/IReadOnlySurvey.cs
@@ -6,7 +6,7 @@ using Model.Answer;
 public interface IReadOnlySurvey {
     int SurveyId {get;}
     string SurveyName {get;}
-    bool IsFirst {get;}
+    bool PreviousQuestionExist {get;}
     bool IsLast {get;}
     IEnumerable<IReadOnlyQuestion>? TryGetNextReadOnlyQuestion();
     IEnumerable<IReadOnlyQuestion>? TryGetPreviousReadOnlyQuestion();

--- a/src/Model/Survey/IReadOnlySurvey.cs
+++ b/src/Model/Survey/IReadOnlySurvey.cs
@@ -7,7 +7,7 @@ public interface IReadOnlySurvey {
     int SurveyId {get;}
     string SurveyName {get;}
     bool PreviousQuestionExist {get;}
-    bool IsLast {get;}
+    bool NextQuestionExist {get;}
     IEnumerable<IReadOnlyQuestion>? TryGetNextReadOnlyQuestion();
     IEnumerable<IReadOnlyQuestion>? TryGetPreviousReadOnlyQuestion();
 }

--- a/src/Model/Survey/IReadOnlySurvey.cs
+++ b/src/Model/Survey/IReadOnlySurvey.cs
@@ -6,6 +6,8 @@ using Model.Answer;
 public interface IReadOnlySurvey {
     int SurveyId {get;}
     string SurveyName {get;}
+    bool IsFirst {get;}
+    bool IsLast {get;}
     IEnumerable<IReadOnlyQuestion>? TryGetNextReadOnlyQuestion();
     IEnumerable<IReadOnlyQuestion>? TryGetPreviousReadOnlyQuestion();
 }


### PR DESCRIPTION
Currently `TakeSurveyViewModel` has to save:
* previous set of questions
* current set of questions
* next set of questions

in order to simply check whether this is the last or first page.

So it would be nice with the ability to simple ask for it