### PR TITLE
Allow frontend full parse

### DIFF
--- a/src/Model/Database/DatabaseServices.cs
+++ b/src/Model/Database/DatabaseServices.cs
@@ -1,9 +1,9 @@
-
 namespace Model.Database;
 using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using FrontEndAPI;
 using SurveyWrapper = Model.Survey.SurveyWrapper;
 using Survey = Model.Survey.Survey;
 using Result = Model.Result.Result;
@@ -25,7 +25,7 @@ internal class DatabaseServices : IDatabase {
         if (!File.Exists(resultsPath)) {
             File.Create(resultsPath).Dispose();
         }
-        
+
     }
 
     public bool StoreSurvey(Survey survey) {
@@ -36,14 +36,14 @@ internal class DatabaseServices : IDatabase {
     }
 
     public void StorePictureOverwrite(string src, int surveyId) {
-        string surveyAssetsPath = GetSurveyAssetsPath(surveyId); 
+        string surveyAssetsPath = GetSurveyAssetsPath(surveyId);
         string dest = Path.Combine(surveyAssetsPath, Path.GetFileName(src));
         Directory.CreateDirectory(surveyAssetsPath);
         File.Copy(src, dest, true); //true -> overwrites automatically if dest already exists
     }
 
     public bool TryStorePicture(string src, int surveyId) {
-        string surveyAssetsPath = GetSurveyAssetsPath(surveyId); 
+        string surveyAssetsPath = GetSurveyAssetsPath(surveyId);
         string dest = Path.Combine(surveyAssetsPath, Path.GetFileName(src));
         Directory.CreateDirectory(surveyAssetsPath);
         if (!File.Exists(dest)) {
@@ -74,7 +74,7 @@ internal class DatabaseServices : IDatabase {
     // }
 
     // Tmp int used to increment to get unique IDs, must be received from db.
-    private int tmpId = 0; 
+    private int tmpId = 0;
     public int GetNextSurveyID() {
         return tmpId++;
     }
@@ -125,7 +125,9 @@ internal class DatabaseServices : IDatabase {
     }
 
     public SurveyWrapper GetSurveyWrapper(int surveyId) {
-        return new SurveyWrapper(surveyId);
+        return surveyId == 123456
+            ? ExampleSurvey.GetSurvey()
+            : new SurveyWrapper(surveyId);
     }
 
     public List<SurveyWrapper> GetSurveyWrapperForSuperUser(string username){

--- a/src/Model/Survey/IModifySurveyWrapper.cs
+++ b/src/Model/Survey/IModifySurveyWrapper.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 public interface IModifySurveyWrapper {
     IModifySurvey TryGetModifySurveyVersion(int index); // Return survey index'
 
+    IModifySurvey AddNewVersion();
+
     int GetVersionCount(); // Return number of versions
 
     void CopyVersion(int index);

--- a/src/Model/Survey/IReadOnlySurvey.cs
+++ b/src/Model/Survey/IReadOnlySurvey.cs
@@ -10,4 +10,5 @@ public interface IReadOnlySurvey {
     bool NextQuestionExist();
     IEnumerable<IReadOnlyQuestion>? TryGetNextReadOnlyQuestion();
     IEnumerable<IReadOnlyQuestion>? TryGetPreviousReadOnlyQuestion();
+    void ResetCounter();
 }

--- a/src/Model/Survey/Survey.cs
+++ b/src/Model/Survey/Survey.cs
@@ -12,37 +12,37 @@ internal class Survey : IReadOnlySurvey, IModifySurvey {
 
     private List<List<Question>> surveyQuestions = new List<List<Question>>();
 
-    private int current = 0;
+    private int current = -1;
 
     public Survey(int surveyId) {
         SurveyId = surveyId;
         SurveyName = string.Empty;
     }
 
-    public bool PreviousQuestionExist() => throw new NotImplementedException();
-    public bool NextQuestionExist() => throw new NotImplementedException();
+    public bool PreviousQuestionExist() => current > 0;
+    public bool NextQuestionExist() => current + 1 < surveyQuestions.Count;
 
-    public IEnumerable<IReadOnlyQuestion>? TryGetNextReadOnlyQuestion() {
-        if(0 <= current && current < (surveyQuestions.Count() - 1)) {
-            current++;
-            return surveyQuestions[current];
-        } else {
-            return null;
-        }
+    public IEnumerable<IReadOnlyQuestion>? TryGetNextReadOnlyQuestion()
+    {
+        return NextQuestionExist()
+            ? surveyQuestions[++current]
+            : null;
     }
 
     public IEnumerable<IReadOnlyQuestion>? TryGetPreviousReadOnlyQuestion()
     {
-        if(0 < current && current < (surveyQuestions.Count())) {
-            current--;
-            return surveyQuestions[current];
-        } else {
-            return null;
-        }
+        return PreviousQuestionExist()
+            ? surveyQuestions[--current]
+            : null;
+    }
+
+    public void ResetCounter()
+    {
+        current = -1;
     }
 
     public IEnumerable<IModifyQuestion>? TryGetModifyQuestion(int index) {
-        if(0 <= index && index < (surveyQuestions.Count() - 1)) {
+        if(0 <= index && index < surveyQuestions.Count) {
             current = index;
             return surveyQuestions[index];
         } else {
@@ -51,7 +51,7 @@ internal class Survey : IReadOnlySurvey, IModifySurvey {
     }
     public IEnumerable<IModifyQuestion>? TryGetNextModifyQuestion()
     {
-        if(0 <= current && current < (surveyQuestions.Count() - 1)) {
+        if(0 <= current && NextQuestionExist()) {
             current++;
             return surveyQuestions[current];
         } else {
@@ -60,7 +60,7 @@ internal class Survey : IReadOnlySurvey, IModifySurvey {
     }
 
     public IEnumerable<IModifyQuestion>? TryGetPreviousModifyQuestion() {
-        if(0 < current && current < (surveyQuestions.Count())) {
+        if(PreviousQuestionExist() && current < surveyQuestions.Count) {
             current--;
             return surveyQuestions[current];
         } else {
@@ -69,7 +69,7 @@ internal class Survey : IReadOnlySurvey, IModifySurvey {
     }
 
     public void DeleteQuestion(int index) {
-        if(0 < current && current < (surveyQuestions.Count())) {
+        if(0 < current && current < surveyQuestions.Count) {
             surveyQuestions.RemoveAt(index);
         }
     }

--- a/src/Model/Survey/SurveyWrapper.cs
+++ b/src/Model/Survey/SurveyWrapper.cs
@@ -5,16 +5,16 @@ namespace Model.Survey;
 public class SurveyWrapper : IReadOnlySurveyWrapper, IModifySurveyWrapper {
 
     private int surveyWrapperId;
-    
+
     private string surveyWrapperName;
 
     private string[] surveyAssests;
-    
+
     public int SurveyWrapperId { get => surveyWrapperId;}
     public string SurveyWrapperName { get => surveyWrapperName; set => surveyWrapperName = value;}
 
     private int current = 0;
-    private List<Survey> surveyVersions = new List<Survey>(); 
+    private List<Survey> surveyVersions = new List<Survey>();
 
     public SurveyWrapper (int id) {
         surveyWrapperId = id;
@@ -26,6 +26,14 @@ public class SurveyWrapper : IReadOnlySurveyWrapper, IModifySurveyWrapper {
     public void CopyVersion(int index) {
         // var copiedVersion = surveyVersions[index];
         // surveyVersions.Add(copiedVersion);
+    }
+
+    public IModifySurvey AddNewVersion()
+    {
+        var id = surveyVersions.Count;
+        var survey = new Survey(id);
+        surveyVersions.Add(survey);
+        return survey;
     }
 
     public void DeleteVersion(int index) {
@@ -42,7 +50,7 @@ public class SurveyWrapper : IReadOnlySurveyWrapper, IModifySurveyWrapper {
 
     public IModifySurvey TryGetModifySurveyVersion(int index)
     {
-        if(0 <= index && index < (surveyVersions.Count() - 1)) { 
+        if(0 <= index && index < surveyVersions.Count) {
             current = index;
             return surveyVersions[index];
         } else {
@@ -52,7 +60,7 @@ public class SurveyWrapper : IReadOnlySurveyWrapper, IModifySurveyWrapper {
 
     public IReadOnlySurvey TryGetReadOnlySurveyVersion(int index)
     {
-        if(0 <= index && index < (surveyVersions.Count() - 1)) { 
+        if(0 <= index && index < surveyVersions.Count) {
             current = index;
             return surveyVersions[index];
         } else {

--- a/src/Model/tmp_Moc/ExampleSurvey.cs
+++ b/src/Model/tmp_Moc/ExampleSurvey.cs
@@ -1,0 +1,71 @@
+using Model.Answer;
+using Model.Survey;
+using Model.Question;
+
+namespace Model.FrontEndAPI;
+
+using Question = Model.Question.Question;
+public static class ExampleSurvey
+{
+    private static int _questionId = 0;
+    private static Question GetScaleQuestion(string caption, string image, string text, int min, int max)
+    {
+        var question = new Question(_questionId++);
+        question.ModifyCaption = caption;
+        question.ModifyPicture = image;
+        question.ModifyText = text;
+        var answer = question.ModifyAnswer;
+        answer.AddAnswerOption(min.ToString());
+        answer.AddAnswerOption(max.ToString());
+        answer.ModifyAnswerType = AnswerType.Scale;
+        return question;
+    }
+
+    private static Question GetMultiQuestion(string caption, string image, string text, string[] options)
+    {
+        var question = new Question(_questionId++);
+        question.ModifyCaption = caption;
+        question.ModifyPicture = image;
+        question.ModifyText = text;
+        var answer = question.ModifyAnswer;
+        foreach (var option in options)
+        {
+            answer.AddAnswerOption(option);
+        }
+        answer.ModifyAnswerType = AnswerType.MultipleChoice;
+        return question;
+    }
+
+    public static SurveyWrapper GetSurvey()
+    {
+        var q1 = GetScaleQuestion(
+            "Caption1",
+            "/home/jonas/Pictures/Screenshots/hej.png",
+            "Question1",
+            1,
+            8);
+        var q2 = GetScaleQuestion(
+            string.Empty,
+            string.Empty,
+            "Question2",
+            1, 3);
+        var q3 = GetMultiQuestion(
+            "Multi Question example",
+            string.Empty,
+            "Question3",
+            ["This", "that", "Naah"]);
+
+
+
+        var surveyWrap = new SurveyWrapper(123456);
+        var survey = surveyWrap.AddNewVersion();
+        var page1 = survey.AddNewQuestion();
+        ((List<Question>)page1).Add(q1);
+        ((List<Question>)page1).Add(q2);
+
+        var page2 = survey.AddNewQuestion();
+        ((List<Question>)page2).Add(q3);
+
+        return surveyWrap;
+    }
+}

--- a/src/Model/tmp_Moc/ExampleSurvey.cs
+++ b/src/Model/tmp_Moc/ExampleSurvey.cs
@@ -40,7 +40,7 @@ public static class ExampleSurvey
     {
         var q1 = GetScaleQuestion(
             "Caption1",
-            "/home/jonas/Pictures/Screenshots/hej.png",
+            string.Empty,
             "Question1",
             1,
             8);

--- a/src/scivu/scivu/ViewModels/SurveyTakeViewModel.cs
+++ b/src/scivu/scivu/ViewModels/SurveyTakeViewModel.cs
@@ -65,6 +65,7 @@ public class SurveyTakeViewModel : ViewModelBase
         _userId = userId;
         _wrapper = surveyWrapper;
         _survey = ChooseSurvey(surveyWrapper);
+        _survey.ResetCounter();
         _results.Clear();
         _results.Add(new List<Result>());
         _resultIdx = 0;


### PR DESCRIPTION
This allows a full parse on the experimenter side of the front end.

It does the following:
1. Adds a hardcoded survey in `ExampleSurvey`
2. Adds `IModifySurvey IModifySurveyWrapper.AddNewVersion()` so we can add versions to wrappers
3. Fill out some functionality and fixes some indexing

# Testing
I have simply done manual tests by going through the various front end menus