### PR TITLE
Fixing delete surveywrapper

### DIFF
--- a/src/Model/Database/DatabaseServices.cs
+++ b/src/Model/Database/DatabaseServices.cs
@@ -87,7 +87,7 @@ internal class DatabaseServices : IDatabase {
             surveyWrapperList.Remove(surveyWrapperId);
         }
 
-        //is it necessary to explicitly update creatorDicts list?
+        //is it necessary to explicitly update creatorDicts list before storing it?
         creatorDict[username] = surveyWrapperList; 
         StoreCreatorDict(creatorDict);
 

--- a/src/Model/Database/DatabaseServices.cs
+++ b/src/Model/Database/DatabaseServices.cs
@@ -69,8 +69,28 @@ internal class DatabaseServices : IDatabase {
         return true;
     }
 
-    public bool DeleteSurveyWrapper(int surveyWrapperId) {
+    public bool DeleteSurveyWrapper(int surveyWrapperId, string username) {
         string surveyWrapperPath = GetSurveyWrapperPath(surveyWrapperId);
+        Dictionary<string, List<int>> creatorDict = GetCreatorDict();
+        List<int> surveyWrapperList;
+
+        if (!creatorDict.ContainsKey(username)) {
+            return false;
+        }
+        surveyWrapperList = creatorDict[username];
+
+        if (!surveyWrapperList.Contains(surveyWrapperId)) {
+            return false;
+        }        
+
+        while (surveyWrapperList.Contains(surveyWrapperId)) {
+            surveyWrapperList.Remove(surveyWrapperId);
+        }
+
+        //is it necessary to explicitly update creatorDicts list?
+        creatorDict[username] = surveyWrapperList; 
+        StoreCreatorDict(creatorDict);
+
         if (Directory.Exists(surveyWrapperPath)) {
             Directory.Delete(surveyWrapperPath, true);
             return true;
@@ -158,6 +178,7 @@ internal class DatabaseServices : IDatabase {
         string jsonString = JsonSerializer.Serialize(creatorDict, Globals.OPTIONS);
         File.WriteAllText(creatorDictPath, jsonString);
     }
+
 
     public bool ExportSurveyWrapper(int id, string path) {
         string surveyWrapperPath = GetSurveyWrapperPath(id);

--- a/src/Model/Database/DatabaseServices.cs
+++ b/src/Model/Database/DatabaseServices.cs
@@ -87,9 +87,9 @@ internal class DatabaseServices : IDatabase {
             surveyWrapperList.Remove(surveyWrapperId);
         }
 
-        //is it necessary to explicitly update creatorDicts list before storing it?
-        creatorDict[username] = surveyWrapperList; 
         StoreCreatorDict(creatorDict);
+        creatorDict = GetCreatorDict();
+
 
         if (Directory.Exists(surveyWrapperPath)) {
             Directory.Delete(surveyWrapperPath, true);

--- a/src/Model/Database/IDatabase.cs
+++ b/src/Model/Database/IDatabase.cs
@@ -8,7 +8,7 @@ using Model.Survey;
 internal interface IDatabase {
     int GetNextSurveyWrapperID(string superUserName);
     bool StoreSurveyWrapper(SurveyWrapper surveyWrapper);
-    bool DeleteSurveyWrapper(int surveyWrapperId);
+    bool DeleteSurveyWrapper(int surveyWrapperId, string username);
     SurveyWrapper? GetSurveyWrapper(int surveyWrapperId);
     List<SurveyWrapper>? GetSurveyWrapperForSuperUser(string username);
     bool ExportSurveyWrapper(int surveyWrapperid,string path);

--- a/src/Model/FrontEndAPI/FrontEndSuperUserMenu.cs
+++ b/src/Model/FrontEndAPI/FrontEndSuperUserMenu.cs
@@ -30,8 +30,8 @@ internal class FrontEndSuperUserMenu : IFrontEndSuperUser {
         return newSurveyWrapper;
     }
 
-    public bool DeleteSurveyWrapper(int surveyId) {
-        if (db.DeleteSurveyWrapper(surveyId)) {
+    public bool DeleteSurveyWrapper(int surveyId, string username) {
+        if (db.DeleteSurveyWrapper(surveyId, username)) {
             return true;
         } else {
             return false;

--- a/src/Model/FrontEndAPI/IFrontEndSuperUser.cs
+++ b/src/Model/FrontEndAPI/IFrontEndSuperUser.cs
@@ -6,7 +6,7 @@ public interface IFrontEndSuperUser {
     List<IModifySurveyWrapper>? GetSurveyWrappersFromSuperUser(string username);
     IModifySurveyWrapper CreateSurveyWrapper(string superUserName, string surveyWrapperName);
     IModifySurveyWrapper? ModifySurveyWrapper(int surveyWrapperId); // Possibly (SuperUserId, SurveyId)?
-    bool DeleteSurveyWrapper(int surveyWrapperId);
+    bool DeleteSurveyWrapper(int surveyWrapperId, string username);
 
     void StoreSurveyWrapperInDatabase (IModifySurveyWrapper surveyWrapper);
 

--- a/src/Tests/Backend/Database/TestDeleteSurveyWrapper.cs
+++ b/src/Tests/Backend/Database/TestDeleteSurveyWrapper.cs
@@ -11,14 +11,28 @@ using Model.Question;
 [TestFixture]
 internal class TestDeleteSurveyWrapper {   
    
-   string testDB = ("testDB");
+    string testDB = ("testDB");
     DatabaseServices database;
+
+    string username;
+
+    string otherUser;
+
+    int id;
     SurveyWrapper surveyWrapper;
+
+    List<SurveyWrapper> surveyWrappers;
+
+    bool res;
+    
     [SetUp]
     public void SetUp() {
         database = new DatabaseServices(testDB);
-
-
+        username = "sippo";
+        otherUser = "notsippo";
+        id = database.GetNextSurveyWrapperID(username);
+        surveyWrapper = new SurveyWrapper(id);
+        database.StoreSurveyWrapper(surveyWrapper);
     }
 
     [TearDown]
@@ -37,24 +51,122 @@ internal class TestDeleteSurveyWrapper {
     }
 
     [Test]
-    public void TestDeleteSurveyWrapperThatExists() {
-        // Arrange
-        surveyWrapper = new SurveyWrapper(3);
-        database.StoreSurveyWrapper(surveyWrapper);
-        Assert.That(database.GetSurveyWrapper(3), Is.Not.Null);
-        // Act
-        database.DeleteSurveyWrapper(3);
-        // Assert
-        Assert.That(database.GetSurveyWrapper(3), Is.Null);
+    public void TestDeleteSurveyWrapperThatExistsAndIsOwnedByUser() {
+        // arrange
+        Assert.That(database.GetSurveyWrapper(id), Is.Not.Null);
+
+        // act
+        res = database.DeleteSurveyWrapper(id, username);
+
+        // assert
+        Assert.That(res, Is.True);
+        Assert.That(database.GetSurveyWrapper(id), Is.Null);
+
     }
 
     [Test]
-    public void TestDeleteSurveyWrapperThatDoesNotExist() {
-        // Arrange
-        Assert.That(database.GetSurveyWrapper(3), Is.Null);
-        // Act
-        database.DeleteSurveyWrapper(3);
-        // Assert
-        Assert.That(database.GetSurveyWrapper(3), Is.Null);
+    public void TestDeleteSurveyWrapperThatExistsByNonOwnerNotInCreatorDict() {
+        // arrange
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(otherUser);
+        Assert.That(surveyWrappers == null, Is.True);
+
+        // act
+        res = database.DeleteSurveyWrapper(id, otherUser);
+
+        // assert
+        Assert.That(res, Is.False);
+        Assert.That(database.GetSurveyWrapper(id), Is.Not.Null);
     }
+
+    [Test]
+    public void TestDeleteSurveyWrapperThatExistsByNonOwnerInCreatorDict() {
+        // arrange
+        int newid = database.GetNextSurveyWrapperID(otherUser);
+        SurveyWrapper newSurveyWrapper = new SurveyWrapper(newid);
+        database.StoreSurveyWrapper(newSurveyWrapper);
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(otherUser);
+        Assert.That(surveyWrappers.Count == 1, Is.True);
+        Assert.That(surveyWrappers[0].SurveyWrapperId == newid, Is.True);
+
+        // act
+        res = database.DeleteSurveyWrapper(id, otherUser);
+
+        // assert
+        Assert.That(res, Is.False);
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(otherUser);
+        Assert.That(surveyWrappers.Count == 1, Is.True);
+        Assert.That(surveyWrappers[0].SurveyWrapperId == newid, Is.True);
+        Assert.That(database.GetSurveyWrapper(id), Is.Not.Null);
+        Assert.That(database.GetSurveyWrapper(newid), Is.Not.Null);
+    }
+
+    
+    [Test]
+    public void TestDeleteSurveyWrapperThatDoesNotExists() {
+        // arrange
+        int newid = 1234567;
+        Assert.That(database.GetSurveyWrapper(newid), Is.Null);
+
+        // act
+        res = database.DeleteSurveyWrapper(newid, username);
+
+        // assert
+        Assert.That(res, Is.False);
+        Assert.That(database.GetSurveyWrapper(newid), Is.Null);
+    }
+
+    [Test]
+    public void TestDeleteSurveyWrapperCorrectlyUpdatesCreatorDictWhenOwnedByUser() {
+        // arrange
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(username);
+        Assert.That(surveyWrappers.Count == 1, Is.True);
+        Assert.That(surveyWrappers[0].SurveyWrapperId == id, Is.True);
+
+        // act
+        res = database.DeleteSurveyWrapper(id, username);
+        
+        // assert
+        Assert.That(res, Is.True);
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(username);
+        Assert.That(surveyWrappers.Count == 0, Is.True);
+    }
+
+    [Test]
+    public void TestDeleteSurveyWrapperNotUpdatesOwnersCreatorDictWhenNotOwnedByUser() {
+        // arrange 
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(username);
+        Assert.That(surveyWrappers.Count == 1, Is.True);
+        Assert.That(surveyWrappers[0].SurveyWrapperId == id, Is.True);
+
+        // act 
+        res = database.DeleteSurveyWrapper(id, otherUser);
+        
+        // assert
+        Assert.That(res, Is.False);
+        surveyWrappers = database.GetSurveyWrapperForSuperUser(username);
+        Assert.That(surveyWrappers.Count == 1, Is.True);
+    }
+
+
+    // [Test]
+    // public void TestDeleteSurveyWrapperThatExists() {
+    //     // Arrange
+    //     surveyWrapper = new SurveyWrapper(3);
+    //     database.StoreSurveyWrapper(surveyWrapper);
+    //     Assert.That(database.GetSurveyWrapper(3), Is.Not.Null);
+    //     // Act
+    //     database.DeleteSurveyWrapper(3);
+    //     // Assert
+    //     Assert.That(database.GetSurveyWrapper(3), Is.Null);
+    // }
+
+    // [Test]
+    // public void TestDeleteSurveyWrapperThatDoesNotExist() {
+    //     // Arrange
+    //     Assert.That(database.GetSurveyWrapper(3), Is.Null);
+    //     // Act
+    //     database.DeleteSurveyWrapper(3);
+    //     // Assert
+    //     Assert.That(database.GetSurveyWrapper(3), Is.Null);
+    // }
 }


### PR DESCRIPTION
- DeleteSurveyWrapper now does the following before deleting a surveywrapper:
   - validates that the user trying to delete is the original "owner"/creator 
   - if so, removes the surveywrapper id from the users entry in the creatorDict
- DeleteSurveyWrapper in FrontEndSuperUserMenu has been updated to now need 2 arguments, the survyewrapperid and the username.
- Tests for most cases are included
- There are several cases where the call might fail (user not in creatorDict at all, user not owning the surveywrapper, or surveywrapper not existing) but for now they all just return false (so no info on exactly what caused the problem).